### PR TITLE
Fix Bug where Serial connection to Raspberry Pi Pico does not succeed

### DIFF
--- a/main.c
+++ b/main.c
@@ -57,6 +57,8 @@ void dv(uint32_t delay, uint32_t pulse) {
 
 int main() {
     stdio_init_all();
+    // Sleep X MS to Wait for USB Serial to initialize
+    while (!tud_cdc_connected()) { sleep_ms(100); }
     stdio_set_translate_crlf(&stdio_usb, false);
     pdnd_initialize();
     pdnd_enable_buffers(0);


### PR DESCRIPTION
Added a waiting loop after stdio_init_all() until USB Serial is connected.
On some of my Raspberry pi Picos not doing this resulted in the Serial Connection not working / showing up.

`    // Sleep X MS to Wait for USB Serial to initialize
    while (!tud_cdc_connected()) { sleep_ms(100);  } `